### PR TITLE
Use `// ` for toggle comments instead of `/*` and `*/`

### DIFF
--- a/settings/language-thrift.cson
+++ b/settings/language-thrift.cson
@@ -1,3 +1,4 @@
 '.source.thrift':
   'editor':
+    'commentStart': '// '
     'foldEndPattern': '^\\s*\\}'


### PR DESCRIPTION
I think it's more natural to use `//` rather than combination of `/*` and `*/`.
Tested this locally. Now by `cmd + /` editor converts

```
typedef i64 UserId
```

to 

```
// typedef i64 UserId
```

Instead of

```
/*typedef i64 UserId*/
```
